### PR TITLE
Reduce gas costs by drying the amount of sha3 invocations

### DIFF
--- a/test.js
+++ b/test.js
@@ -43,7 +43,24 @@ if (!fs.existsSync('secrets.json')) {
   mnemonic = secrets.mnemonic;
 }
 
-const testRPCInput = { accounts: generateAccounts(mnemonic, 0, ACCOUNTS, []) };
+const testRPCOutput = {
+  gasCount: 0,
+  log: (output) => {
+    if (output.includes('Gas')) {
+      console.log(output); // Gas usage: 420
+      const gas = output.slice(13);
+
+      testRPCOutput.gasCount += parseInt(gas, 10);
+      console.log('Subtotal:', testRPCOutput.gasCount);
+    }
+  },
+};
+
+const testRPCInput = {
+  accounts: generateAccounts(mnemonic, 0, ACCOUNTS, []),
+  debug: true,
+  logger: testRPCOutput,
+};
 
 TestRPC.server(testRPCInput).listen(8545);
 const truffle = cp.spawn('truffle', ['test']);


### PR DESCRIPTION
By reducing the number of times that the registry contract performs sha3, we can reduce the net gas usage of the contract's lifetime.

**Gas costs to run all tests**
Previously:      68,252,306
After refactor:  67,862,086
Difference:            390,220 (0.57%)

The contract can be further refactored, extracting sha3 from `apply`, `deposit`,`withdraw`, `exit`, `challenge`, and `updateStatus`. This would however require events to emit domain hashes instead of (currently) domain strings.