### PR TITLE
OOP-lite: back from the dead

### DIFF
--- a/contracts/Challenge.sol
+++ b/contracts/Challenge.sol
@@ -5,6 +5,10 @@ import "./historical/StandardToken.sol";
 
 library Challenge {
 
+  // ------
+  // DATA STRUCTURES
+  // ------
+
   struct Data {
     uint rewardPool;        // (remaining) Pool of tokens distributed amongst winning voters
     PLCRVoting voting;      // Address of a PLCRVoting contract
@@ -19,6 +23,10 @@ library Challenge {
         bool))
       tokenClaims;          // maps challengeIDs and address to token claim data
   }
+
+  // --------
+  // GETTERS
+  // --------
 
   /// @dev returns true if the application/listing is initialized
   function isInitialized(Data storage _self) constant public returns (bool) {
@@ -46,7 +54,24 @@ library Challenge {
   }
 
   /**
+  @dev                Calculates the provided voter's token reward for the given poll.
+  @param _voter       The address of the voter whose reward balance is to be returned
+  @param _salt        The salt of the voter's commit hash in the given poll
+  @return             The uint indicating the voter's reward (in nano-ADT)
+  */
+  function voterReward(Data storage _self, address _voter, uint _salt)
+  public constant returns (uint) {
+    uint voterTokens = _self.voting.getNumPassingTokens(_voter, _self.challengeID, _salt);
+    return (voterTokens * _self.rewardPool) / _self.winningTokens;
+  }
+
+  // --------
+  // STATE-CHANGING FUNCTIONS
+  // --------
+
+  /**
   @dev called by a voter to claim his/her reward for each completed vote.
+  @param _voter the address of the voter to claim a reward for
   @param _salt the salt of a voter's commit hash in the given poll
   */
   function claimReward(Data storage _self, address _voter, uint _salt) public returns (uint) {
@@ -68,18 +93,6 @@ library Challenge {
     _self.tokenClaims[_self.challengeID][_voter] = true;
     
     return reward;
-  }
-
-  /**
-  @dev                Calculates the provided voter's token reward for the given poll.
-  @param _voter       The address of the voter whose reward balance is to be returned
-  @param _salt        The salt of the voter's commit hash in the given poll
-  @return             The uint indicating the voter's reward (in nano-ADT)
-  */
-  function voterReward(Data storage _self, address _voter, uint _salt)
-  public constant returns (uint) {
-    uint voterTokens = _self.voting.getNumPassingTokens(_voter, _self.challengeID, _salt);
-    return (voterTokens * _self.rewardPool) / _self.winningTokens;
   }
 }
 

--- a/contracts/Challenge.sol
+++ b/contracts/Challenge.sol
@@ -81,12 +81,5 @@ library Challenge {
     uint voterTokens = _self.voting.getNumPassingTokens(_voter, _self.challengeID, _salt);
     return (voterTokens * _self.rewardPool) / _self.winningTokens;
   }
-
-  function resolve(Data storage _self) public {
-    require(canBeResolved(_self));
-
-    _self.winningTokens = _self.voting.getTotalNumberOfTokensForWinningOption(_self.challengeID);
-    _self.resolved = true;
-  }
 }
 

--- a/contracts/Challenge.sol
+++ b/contracts/Challenge.sol
@@ -1,0 +1,89 @@
+pragma solidity^0.4.11;
+
+import "./PLCRVoting.sol";
+import "./historical/StandardToken.sol";
+
+library Challenge {
+
+  struct Data {
+    uint rewardPool;        // (remaining) Pool of tokens distributed amongst winning voters
+    PLCRVoting voting;      // Address of a PLCRVoting contract
+    StandardToken token;    // Address of an ERC20 token contract
+    uint challengeID;       // An ID corresponding to a pollID in the PLCR contract
+    address challenger;     // Owner of Challenge
+    bool resolved;          // Indication of if challenge is resolved
+    uint stake;             // Number of tokens at risk for either party during challenge
+    uint totalTokens;       // (remaining) Amount of tokens used for voting by the winning side
+    mapping(uint =>
+      mapping(address =>
+        bool))
+      tokenClaims;          // maps challengeIDs and address to token claim data
+  }
+
+  /// @dev returns true if the application/listing is initialized
+  function isInitialized(Data storage _self) constant public returns (bool) {
+    return _self.challengeID > 0;
+  }
+
+  /// @dev returns true if the application/listing has a resolved challenge
+  function isResolved(Data storage _self) constant public returns (bool) {
+    return isInitialized(_self) && _self.resolved;
+  }
+
+  /// @dev determines whether voting has concluded in a challenge for a given domain. Throws if no challenge exists.
+  function canBeResolved(Data storage _self) constant public returns (bool) {
+    return isInitialized(_self) && 
+      _self.voting.pollEnded(_self.challengeID) &&
+      _self.resolved == false;
+  }
+
+  /// @dev determines the number of tokens awarded to the winning party in a challenge.
+  function determineReward(Data storage _self) public constant returns (uint) {
+    // Edge case, nobody voted, give all tokens to the challenger.
+    if (_self.voting.getTotalNumberOfTokensForWinningOption(_self.challengeID) == 0) {
+      return 2 * _self.stake;
+    }
+
+    return (2 * _self.stake) - _self.rewardPool;
+  }
+
+  /**
+  @dev called by a voter to claim his/her reward for each completed vote.
+  @param _salt the salt of a voter's commit hash in the given poll
+  */
+  function claimReward(Data storage _self, address _voter, uint _salt) public returns (uint) {
+    // Ensures the voter has not already claimed tokens and challenge results have been processed
+    require(_self.tokenClaims[_self.challengeID][_voter] == false);
+    require(isResolved(_self));
+
+    uint voterTokens = _self.voting.getNumPassingTokens(_voter, _self.challengeID, _salt);
+    uint reward = calculateVoterReward(_self, _voter, _salt);
+
+    // Subtracts the voter's information to preserve the participation ratios
+    // of other voters compared to the remaining pool of rewards
+    _self.totalTokens -= voterTokens;
+    _self.rewardPool -= reward;
+
+    require(_self.token.transfer(_voter, reward));
+
+    // Ensures a voter cannot claim tokens again
+    _self.tokenClaims[_self.challengeID][_voter] = true;
+    
+    return reward;
+  }
+
+  /**
+  @dev                Calculates the provided voter's token reward for the given poll.
+  @param _voter       The address of the voter whose reward balance is to be returned
+  @param _salt        The salt of the voter's commit hash in the given poll
+  @return             The uint indicating the voter's reward (in nano-ADT)
+  */
+  function calculateVoterReward(Data storage _self, address _voter, uint _salt)
+  public constant returns (uint) {
+    uint totalTokens = _self.totalTokens;
+    uint rewardPool = _self.rewardPool;
+    uint voterTokens = _self.voting.getNumPassingTokens(_voter, _self.challengeID, _salt);
+    return (voterTokens * rewardPool) / totalTokens;
+  }
+}
+

--- a/contracts/Challenge.sol
+++ b/contracts/Challenge.sol
@@ -27,14 +27,12 @@ library Challenge {
 
   /// @dev returns true if the application/listing has a resolved challenge
   function isResolved(Data storage _self) constant public returns (bool) {
-    return isInitialized(_self) && _self.resolved;
+    return _self.resolved;
   }
 
   /// @dev determines whether voting has concluded in a challenge for a given domain. Throws if no challenge exists.
   function canBeResolved(Data storage _self) constant public returns (bool) {
-    return isInitialized(_self) && 
-      _self.voting.pollEnded(_self.challengeID) &&
-      _self.resolved == false;
+    return _self.voting.pollEnded(_self.challengeID) && _self.resolved == false;
   }
 
   /// @dev determines the number of tokens awarded to the winning party in a challenge.

--- a/contracts/Parameterizer.sol
+++ b/contracts/Parameterizer.sol
@@ -278,7 +278,9 @@ contract Parameterizer {
       require(token.transfer(challenges[prop.challengeID].challenger, reward));
     }
 
-    challenge.resolve();
+    challenge.winningTokens =
+      challenge.voting.getTotalNumberOfTokensForWinningOption(challenge.challengeID);
+    challenge.resolved = true;
   }
 }
 

--- a/contracts/Parameterizer.sol
+++ b/contracts/Parameterizer.sol
@@ -224,7 +224,8 @@ contract Parameterizer {
   @param _propID The proposal ID whose challenge to inspect
   */
   function challengeCanBeResolved(bytes32 _propID) constant public returns (bool) {
-    return challenges[proposalMap[_propID].challengeID].canBeResolved();
+    Challenge.Data storage challenge = challenges[proposalMap[_propID].challengeID];
+    return challenge.isInitialized() && challenge.canBeResolved();
   }
 
   /**

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -7,379 +7,390 @@ import "./PLCRVoting.sol";
 
 contract Registry {
 
-    // ------
-    // EVENTS
-    // ------
+  // ------
+  // EVENTS
+  // ------
 
-    event _Application(string domain, uint deposit);
-    event _Challenge(string domain, uint deposit, uint pollID);
-    event _Deposit(string domain, uint added, uint newTotal);
-    event _Withdrawal(string domain, uint withdrew, uint newTotal);
-    event _NewDomainWhitelisted(string domain);
-    event _ApplicationRemoved(string domain);
-    event _ListingRemoved(string domain);
-    event _ChallengeFailed(uint challengeID);
-    event _ChallengeSucceeded(uint challengeID);
-    event _RewardClaimed(address voter, uint challengeID, uint reward);
+  event _Application(string domain, uint deposit);
+  event _Challenge(string domain, uint deposit, uint pollID);
+  event _Deposit(string domain, uint added, uint newTotal);
+  event _Withdrawal(string domain, uint withdrew, uint newTotal);
+  event _NewDomainWhitelisted(string domain);
+  event _ApplicationRemoved(string domain);
+  event _ListingRemoved(string domain);
+  event _ChallengeFailed(uint challengeID);
+  event _ChallengeSucceeded(uint challengeID);
+  event _RewardClaimed(address voter, uint challengeID, uint reward);
 
-    struct Listing {
-        uint applicationExpiry; // Expiration date of apply stage
-        bool whitelisted;       // Indicates registry status
-        address owner;          // Owner of Listing
-        uint unstakedDeposit;   // Number of unlocked tokens with potential risk if challenged
-        uint challengeID;       // Identifier of canonical challenge
+  // ------
+  // DATA STRUCTURES
+  // ------
+
+  using Challenge for Challenge.Data;
+
+  struct Listing {
+    uint applicationExpiry; // Expiration date of apply stage
+    bool whitelisted;       // Indicates registry status
+    address owner;          // Owner of Listing
+    uint unstakedDeposit;   // Number of unlocked tokens with potential risk if challenged
+    uint challengeID;       // Identifier of canonical challenge
+  }
+
+  // ------
+  // STATE
+  // ------
+
+  // Maps challengeIDs to associated challenge data
+  mapping(uint => Challenge.Data) public challenges;
+
+  // Maps domainHashes to associated listing data
+  mapping(bytes32 => Listing) public listings;
+
+  // Global Variables
+  StandardToken public token;
+  PLCRVoting public voting;
+  Parameterizer public parameterizer;
+
+  // ------------
+  // CONSTRUCTOR
+  // ------------
+
+  /**
+  @dev Contructor
+  @notice                 Sets the addresses for token, voting, and parameterizer
+  @param _tokenAddr       Address of the native ERC20 token (ADT)
+  @param _plcrAddr        Address of a PLCR voting contract for the provided token
+  @param _paramsAddr      Address of a Parameterizer contract for the provided PLCR voting contract
+  */
+  function Registry(
+    address _tokenAddr,
+    address _plcrAddr,
+    address _paramsAddr
+  ) {
+    token = StandardToken(_tokenAddr);
+    voting = PLCRVoting(_plcrAddr);
+    parameterizer = Parameterizer(_paramsAddr);
+  }
+
+  // --------------------
+  // PUBLISHER INTERFACE
+  // --------------------
+
+  /**
+  @notice             Allows a user to start an application.
+  @notice             Takes tokens from user and sets apply stage end time.
+  @param _domain      The domain of a potential listing a user is applying to add to the registry
+  @param _amount      The number of ERC20 tokens a user is willing to potentially stake
+  */
+  function apply(string _domain, uint _amount) external {
+    require(!isWhitelisted(_domain));
+    require(!appWasMade(_domain));
+    require(_amount >= parameterizer.get("minDeposit"));
+
+    // Sets owner
+    Listing storage listing = listings[keccak256(_domain)];
+    listing.owner = msg.sender;
+
+    // Transfers tokens from user to Registry contract
+    require(token.transferFrom(listing.owner, this, _amount));
+
+    // Sets apply stage end time
+    listing.applicationExpiry = block.timestamp + parameterizer.get("applyStageLen");
+    listing.unstakedDeposit = _amount;
+
+    _Application(_domain, _amount);
+  }
+
+  /**
+  @notice             Allows the owner of a domain to increase their unstaked deposit.
+  @param _domain      The domain of a user's application/listing
+  @param _amount      The number of ERC20 tokens to increase a user's unstaked deposit
+  */
+  function deposit(string _domain, uint _amount) external {
+    Listing storage listing = listings[keccak256(_domain)];
+
+    require(listing.owner == msg.sender);
+    require(token.transferFrom(msg.sender, this, _amount));
+
+    listing.unstakedDeposit += _amount;
+
+    _Deposit(_domain, _amount, listing.unstakedDeposit);
+  }
+
+  /**
+  @notice             Allows the owner of a domain to decrease their unstaked deposit.
+  @notice             The listing keeps its previous status.
+  @param _domain      The domain of a user's application/listing
+  @param _amount      The number of ERC20 tokens to decrease a user's unstaked deposit
+  */
+  function withdraw(string _domain, uint _amount) external {
+    Listing storage listing = listings[keccak256(_domain)];
+
+    require(listing.owner == msg.sender);
+    require(_amount <= listing.unstakedDeposit);
+    require(listing.unstakedDeposit - _amount >= parameterizer.get("minDeposit"));
+
+    require(token.transfer(msg.sender, _amount));
+
+    listing.unstakedDeposit -= _amount;
+
+    _Withdrawal(_domain, _amount, listing.unstakedDeposit);
+  }
+
+  /**
+  @notice             Allows the owner of a listing to remove the listing from the whitelist
+  @notice             Returns all tokens to the owner of the listing
+  @param _domain      The domain of a user's listing
+  */
+  function exit(string _domain) external {
+    Listing storage listing = listings[keccak256(_domain)];
+
+    require(msg.sender == listing.owner);
+    require(isWhitelisted(_domain));
+
+    // Cannot exit during ongoing challenge
+    require(!challenges[listing.challengeID].isInitialized() ||
+            challenges[listing.challengeID].isResolved());
+
+    // Remove domain & return tokens
+    resetListing(_domain);
+  }
+
+  // -----------------------
+  // TOKEN HOLDER INTERFACE
+  // -----------------------
+
+  /**
+  @notice             Starts a poll for a domain which is either
+  @notice             in the apply stage or already in the whitelist.
+  @dev                Tokens are taken from the challenger and the applicant's deposit is locked.
+  @param _domain      The domain of an applicant's potential listing
+  */
+  function challenge(string _domain) external returns (uint challengeID) {
+    bytes32 domainHash = keccak256(_domain);
+    Listing storage listing = listings[domainHash];
+    uint deposit = parameterizer.get("minDeposit");
+
+    // Domain must be in apply stage or already on the whitelist
+    require(appWasMade(_domain) || listing.whitelisted);
+    // Prevent multiple challenges
+    require(!challenges[listing.challengeID].isInitialized() ||
+            challenges[listing.challengeID].isResolved());
+
+    if (listing.unstakedDeposit < deposit) {
+      // Not enough tokens, domain auto-delisted
+      resetListing(_domain);
+      return 0;
     }
 
-    // Maps challengeIDs to associated challenge data
-    using Challenge for Challenge.Data;
-    mapping(uint => Challenge.Data) public challenges;
+    // Takes tokens from challenger
+    require(token.transferFrom(msg.sender, this, deposit));
 
-    // Maps domainHashes to associated listing data
-    mapping(bytes32 => Listing) public listingMap;
+    // Starts poll
+    uint pollID = voting.startPoll(
+      parameterizer.get("voteQuorum"),
+      parameterizer.get("commitStageLen"),
+      parameterizer.get("revealStageLen")
+    );
 
-    // Global Variables
-    StandardToken public token;
-    PLCRVoting public voting;
-    Parameterizer public parameterizer;
+    challenges[pollID] = Challenge.Data({
+      challenger: msg.sender,
+      voting: voting,
+      token: token,
+      challengeID: pollID,
+      rewardPool: ((100 - parameterizer.get("dispensationPct")) * deposit) / 100,
+      stake: deposit,
+      resolved: false,
+      winningTokens: 0
+    });
 
-    // ------------
-    // CONSTRUCTOR:
-    // ------------
+    // Updates listing to store most recent challenge
+    listings[domainHash].challengeID = pollID;
 
-    /**
-    @dev Contructor
-    @notice                 Sets the addresses for token, voting, and parameterizer
-    @param _tokenAddr       Address of the native ERC20 token (ADT)
-    @param _plcrAddr        Address of a PLCR voting contract for the provided token
-    @param _paramsAddr      Address of a Parameterizer contract for the provided PLCR voting contract
-    */
-    function Registry(
-        address _tokenAddr,
-        address _plcrAddr,
-        address _paramsAddr
-    ) {
-        token = StandardToken(_tokenAddr);
-        voting = PLCRVoting(_plcrAddr);
-        parameterizer = Parameterizer(_paramsAddr);
+    // Locks tokens for listing during challenge
+    listings[domainHash].unstakedDeposit -= deposit;
+
+    _Challenge(_domain, deposit, pollID);
+    return pollID;
+  }
+
+  /**
+  @notice             Called by a voter to claim his/her reward for each completed vote.
+  @dev                Someone must call updateStatus() before this can be called.
+  @param _challengeID The pollID of the challenge a reward is being claimed for
+  @param _salt        The salt of a voter's commit hash in the given poll
+  */
+  function claimReward(uint _challengeID, uint _salt) public {
+    uint reward = challenges[_challengeID].claimReward(msg.sender, _salt);
+
+    _RewardClaimed(msg.sender, _challengeID, reward);
+  }
+
+  /**
+  @notice             Updates a domain's status from 'application' to 'listing'
+  @notice             or resolves a challenge if one exists.
+  @param _domain      The domain whose status is being updated
+  */
+  function updateStatus(string _domain) public {
+    if (canBeWhitelisted(_domain)) {
+      whitelistApplication(_domain);
+      _NewDomainWhitelisted(_domain);
+    } else if (challengeCanBeResolved(_domain)) {
+      resolveChallenge(_domain);
+    } else {
+      revert();
+    }
+  }
+
+  // --------
+  // GETTERS
+  // --------
+
+  /**
+  @dev                Determines whether the domain of an application can be whitelisted.
+  @param _domain      The domain whose status should be examined
+  */
+  function canBeWhitelisted(string _domain) constant public returns (bool) {
+    bytes32 domainHash = keccak256(_domain);
+    uint challengeID = listings[domainHash].challengeID;
+
+    // Ensures that the application was made,
+    // the application period has ended,
+    // the domain can be whitelisted,
+    // and either: the challengeID == 0, or the challenge has been resolved.
+    if (
+        appWasMade(_domain) &&
+        isExpired(listings[domainHash].applicationExpiry) &&
+        !isWhitelisted(_domain) &&
+        (!challenges[challengeID].isInitialized() || challenges[challengeID].isResolved())
+    ) { return true; }
+
+    return false;
+  }
+
+  /// @dev returns true if domain is whitelisted
+  function isWhitelisted(string _domain) constant public returns (bool whitelisted) {
+    return listings[keccak256(_domain)].whitelisted;
+  }
+
+  // @dev returns true if apply was called for this domain
+  function appWasMade(string _domain) constant public returns (bool exists) {
+    return listings[keccak256(_domain)].applicationExpiry > 0;
+  }
+
+  // @dev returns true if the application/listing has an unresolved challenge
+  function challengeExists(string _domain) constant public returns (bool) {
+    Challenge.Data storage challenge = challenges[listings[keccak256(_domain)].challengeID];
+      return challenge.isInitialized() && !challenge.isResolved();
+  }
+
+  /**
+  @notice             Determines whether voting has concluded in a challenge for a given domain.
+  @dev                Throws if no challenge exists.
+  @param _domain      A domain with an unresolved challenge
+  */
+  function challengeCanBeResolved(string _domain) constant public returns (bool) {
+    Challenge.Data storage challenge = challenges[listings[keccak256(_domain)].challengeID];
+    return challenge.isInitialized() && challenge.canBeResolved();
+  }
+
+  /**
+  @notice             Determines the number of tokens awarded to the winning party in a challenge.
+  @param _challengeID The challengeID to determine a reward for
+  */
+  function challengeWinnerReward(uint _challengeID) public constant returns (uint) {
+    return challenges[_challengeID].challengeWinnerReward(); 
+  }
+
+  /// @dev returns true if the provided termDate has passed
+  function isExpired(uint _termDate) constant public returns (bool expired) {
+    return _termDate < block.timestamp;
+  }
+
+  /**
+  @dev                Calculates the provided voter's token reward for the given poll.
+  @param _voter       The address of the voter whose reward balance is to be returned
+  @param _challengeID The ID of the challenge the voter's reward is being calculated for
+  @param _salt        The salt of the voter's commit hash in the given poll
+  @return             The uint indicating the voter's reward (in nano-ADT)
+  */
+  function voterReward(address _voter, uint _challengeID, uint _salt)
+  public constant returns (uint) {
+    return challenges[_challengeID].voterReward(_voter, _salt);
+  }
+
+  // ----------------
+  // PRIVATE FUNCTIONS
+  // ----------------
+
+  /**
+  @dev Determines the winner in a challenge. Rewards the winner tokens and either whitelists or
+  de-whitelists the domain.
+  @param _domain A domain with a challenge that is to be resolved.
+  */
+  function resolveChallenge(string _domain) private {
+    bytes32 domainHash = keccak256(_domain);
+    Listing storage listing = listings[domainHash];
+    Challenge.Data storage challenge = challenges[listing.challengeID];
+
+    // Calculates the winner's reward,
+    // which is: (winner's full stake) + (dispensationPct * loser's stake)
+    uint winnerReward = challenge.challengeWinnerReward();
+
+    // Records whether the domain is a listing or an application
+    bool wasWhitelisted = isWhitelisted(_domain);
+
+    // Case: challenge failed
+    if (voting.isPassed(challenge.challengeID)) {
+      whitelistApplication(_domain);
+      // Unlock stake so that it can be retrieved by the applicant
+      listing.unstakedDeposit += winnerReward;
+
+      _ChallengeFailed(challenge.challengeID);
+      if (!wasWhitelisted) { _NewDomainWhitelisted(_domain); }
+    }
+    // Case: challenge succeeded
+    else {
+      resetListing(_domain);
+      // Transfer the reward to the challenger
+      require(token.transfer(challenge.challenger, winnerReward));
+
+      _ChallengeSucceeded(challenge.challengeID);
+      if (wasWhitelisted) { _ListingRemoved(_domain); }
+      else { _ApplicationRemoved(_domain); }
     }
 
-    // --------------------
-    // PUBLISHER INTERFACE:
-    // --------------------
+    challenge.winningTokens =
+      challenge.voting.getTotalNumberOfTokensForWinningOption(challenge.challengeID);
+    challenge.resolved = true;
+  }
 
-    /**
-    @notice             Allows a user to start an application.
-    @notice             Takes tokens from user and sets apply stage end time.
-    @param _domain      The domain of a potential listing a user is applying to add to the registry
-    @param _amount      The number of ERC20 tokens a user is willing to potentially stake
-    */
-    function apply(string _domain, uint _amount) external {
-        require(!isWhitelisted(_domain));
-        require(!appWasMade(_domain));
-        require(_amount >= parameterizer.get("minDeposit"));
+  /**
+  @dev Called by updateStatus() if the applicationExpiry date passed without a
+  challenge being made
+  @dev Called by resolveChallenge() if an application/listing beat a challenge.
+  @param _domain The domain of an application/listing to be whitelisted
+  */
+  function whitelistApplication(string _domain) private {
+    bytes32 domainHash = keccak256(_domain);
 
-        // Sets owner
-        Listing storage listing = listingMap[keccak256(_domain)];
-        listing.owner = msg.sender;
+    listings[domainHash].whitelisted = true;
+  }
 
-        // Transfers tokens from user to Registry contract
-        require(token.transferFrom(listing.owner, this, _amount));
+  /**
+  @dev deletes a listing from the whitelist and transfers tokens back to owner
+  @param _domain the domain to be removed
+  */
+  function resetListing(string _domain) private {
+    bytes32 domainHash = keccak256(_domain);
+    Listing storage listing = listings[domainHash];
 
-        // Sets apply stage end time
-        listing.applicationExpiry = block.timestamp + parameterizer.get("applyStageLen");
-        listing.unstakedDeposit = _amount;
+    // Transfers any remaining balance back to the owner
+    if (listing.unstakedDeposit > 0)
+        require(token.transfer(listing.owner, listing.unstakedDeposit));
 
-        _Application(_domain, _amount);
-    }
+    delete listings[domainHash];
+  }
 
-    /**
-    @notice             Allows the owner of a domain to increase their unstaked deposit.
-    @param _domain      The domain of a user's application/listing
-    @param _amount      The number of ERC20 tokens to increase a user's unstaked deposit
-    */
-    function deposit(string _domain, uint _amount) external {
-        Listing storage listing = listingMap[keccak256(_domain)];
 
-        require(listing.owner == msg.sender);
-        require(token.transferFrom(msg.sender, this, _amount));
-
-        listing.unstakedDeposit += _amount;
-
-        _Deposit(_domain, _amount, listing.unstakedDeposit);
-    }
-
-    /**
-    @notice             Allows the owner of a domain to decrease their unstaked deposit.
-    @notice             The listing keeps its previous status.
-    @param _domain      The domain of a user's application/listing
-    @param _amount      The number of ERC20 tokens to decrease a user's unstaked deposit
-    */
-    function withdraw(string _domain, uint _amount) external {
-        Listing storage listing = listingMap[keccak256(_domain)];
-
-        require(listing.owner == msg.sender);
-        require(_amount <= listing.unstakedDeposit);
-        require(listing.unstakedDeposit - _amount >= parameterizer.get("minDeposit"));
-
-        require(token.transfer(msg.sender, _amount));
-
-        listing.unstakedDeposit -= _amount;
-
-        _Withdrawal(_domain, _amount, listing.unstakedDeposit);
-    }
-
-    /**
-    @notice             Allows the owner of a listing to remove the listing from the whitelist
-    @notice             Returns all tokens to the owner of the listing
-    @param _domain      The domain of a user's listing
-    */
-    function exit(string _domain) external {
-        Listing storage listing = listingMap[keccak256(_domain)];
-
-        require(msg.sender == listing.owner);
-        require(isWhitelisted(_domain));
-
-        // Cannot exit during ongoing challenge
-        require(!challenges[listing.challengeID].isInitialized() ||
-                challenges[listing.challengeID].isResolved());
-
-        // Remove domain & return tokens
-        resetListing(_domain);
-    }
-
-    // -----------------------
-    // TOKEN HOLDER INTERFACE:
-    // -----------------------
-
-    /**
-    @notice             Starts a poll for a domain which is either
-    @notice             in the apply stage or already in the whitelist.
-    @dev                Tokens are taken from the challenger and the applicant's deposit is locked.
-    @param _domain      The domain of an applicant's potential listing
-    */
-    function challenge(string _domain) external returns (uint challengeID) {
-        bytes32 domainHash = keccak256(_domain);
-        Listing storage listing = listingMap[domainHash];
-        uint deposit = parameterizer.get("minDeposit");
-
-        // Domain must be in apply stage or already on the whitelist
-        require(appWasMade(_domain) || listing.whitelisted);
-        // Prevent multiple challenges
-        require(!challenges[listing.challengeID].isInitialized() ||
-                challenges[listing.challengeID].isResolved());
-
-        if (listing.unstakedDeposit < deposit) {
-            // Not enough tokens, domain auto-delisted
-            resetListing(_domain);
-            return 0;
-        }
-
-        // Takes tokens from challenger
-        require(token.transferFrom(msg.sender, this, deposit));
-
-        // Starts poll
-        uint pollID = voting.startPoll(
-            parameterizer.get("voteQuorum"),
-            parameterizer.get("commitStageLen"),
-            parameterizer.get("revealStageLen")
-        );
-
-        challenges[pollID] = Challenge.Data({
-            challenger: msg.sender,
-            voting: voting,
-            token: token,
-            challengeID: pollID,
-            rewardPool: ((100 - parameterizer.get("dispensationPct")) * deposit) / 100,
-            stake: deposit,
-            resolved: false,
-            winningTokens: 0
-        });
-
-        // Updates listing to store most recent challenge
-        listingMap[domainHash].challengeID = pollID;
-
-        // Locks tokens for listing during challenge
-        listingMap[domainHash].unstakedDeposit -= deposit;
-
-        _Challenge(_domain, deposit, pollID);
-        return pollID;
-    }
-
-    /**
-    @notice             Updates a domain's status from 'application' to 'listing'
-    @notice             or resolves a challenge if one exists.
-    @param _domain      The domain whose status is being updated
-    */
-    function updateStatus(string _domain) public {
-        if (canBeWhitelisted(_domain)) {
-          whitelistApplication(_domain);
-          _NewDomainWhitelisted(_domain);
-        } else if (challengeCanBeResolved(_domain)) {
-          resolveChallenge(_domain);
-        } else {
-          revert();
-        }
-    }
-
-    // ----------------
-    // TOKEN FUNCTIONS:
-    // ----------------
-
-    /**
-    @notice             Called by a voter to claim his/her reward for each completed vote.
-    @dev                Someone must call updateStatus() before this can be called.
-    @param _challengeID The pollID of the challenge a reward is being claimed for
-    @param _salt        The salt of a voter's commit hash in the given poll
-    */
-    function claimReward(uint _challengeID, uint _salt) public {
-        uint reward = challenges[_challengeID].claimReward(msg.sender, _salt);
-
-        _RewardClaimed(msg.sender, _challengeID, reward);
-    }
-
-    // --------
-    // GETTERS:
-    // --------
-
-    /**
-    @dev                Determines whether the domain of an application can be whitelisted.
-    @param _domain      The domain whose status should be examined
-    */
-    function canBeWhitelisted(string _domain) constant public returns (bool) {
-        bytes32 domainHash = keccak256(_domain);
-        uint challengeID = listingMap[domainHash].challengeID;
-
-        // Ensures that the application was made,
-        // the application period has ended,
-        // the domain can be whitelisted,
-        // and either: the challengeID == 0, or the challenge has been resolved.
-        if (
-            appWasMade(_domain) &&
-            isExpired(listingMap[domainHash].applicationExpiry) &&
-            !isWhitelisted(_domain) &&
-            (!challenges[challengeID].isInitialized() || challenges[challengeID].isResolved())
-        ) { return true; }
-
-        return false;
-    }
-
-    // Returns true if domain is whitelisted
-    function isWhitelisted(string _domain) constant public returns (bool whitelisted) {
-        return listingMap[keccak256(_domain)].whitelisted;
-    }
-
-    // Returns true if apply(domain) was called for this domain
-    function appWasMade(string _domain) constant public returns (bool exists) {
-        return listingMap[keccak256(_domain)].applicationExpiry > 0;
-    }
-
-    // Returns true if the application/listing has an unresolved challenge
-    function challengeExists(string _domain) constant public returns (bool) {
-        Challenge.Data storage challenge = challenges[listingMap[keccak256(_domain)].challengeID];
-        return challenge.isInitialized() && !challenge.isResolved();
-    }
-
-    /**
-    @notice             Determines whether voting has concluded in a challenge for a given domain.
-    @dev                Throws if no challenge exists.
-    @param _domain      A domain with an unresolved challenge
-    */
-    function challengeCanBeResolved(string _domain) constant public returns (bool) {
-        Challenge.Data storage challenge = challenges[listingMap[keccak256(_domain)].challengeID];
-        return challenge.isInitialized() && challenge.canBeResolved();
-    }
-
-    /**
-    @notice             Determines the number of tokens awarded to the winning party in a challenge.
-    @param _challengeID The challengeID to determine a reward for
-    */
-    function challengeWinnerReward(uint _challengeID) public constant returns (uint) {
-        return challenges[_challengeID].challengeWinnerReward(); 
-    }
-
-    // Returns true if the provided termDate has passed
-    function isExpired(uint _termDate) constant public returns (bool expired) {
-        return _termDate < block.timestamp;
-    }
-
-    // Deletes a listing from the whitelist and transfers tokens back to owner
-    function resetListing(string _domain) internal {
-        bytes32 domainHash = keccak256(_domain);
-        Listing storage listing = listingMap[domainHash];
-
-        // Transfers any remaining balance back to the owner
-        if (listing.unstakedDeposit > 0)
-            require(token.transfer(listing.owner, listing.unstakedDeposit));
-
-        delete listingMap[domainHash];
-    }
-
-    /**
-    @dev                Calculates the provided voter's token reward for the given poll.
-    @param _voter       The address of the voter whose reward balance is to be returned
-    @param _challengeID The ID of the challenge the voter's reward is being calculated for
-    @param _salt        The salt of the voter's commit hash in the given poll
-    @return             The uint indicating the voter's reward (in nano-ADT)
-    */
-    function voterReward(address _voter, uint _challengeID, uint _salt)
-    public constant returns (uint) {
-        return challenges[_challengeID].voterReward(_voter, _salt);
-    }
-
-    // ----------------
-    // PRIVATE FUNCTIONS:
-    // ----------------
-
-    /**
-    @notice             Determines the winner in a challenge.
-    @notice             Rewards the winner tokens and either whitelists or de-whitelists the domain.
-    @param _domain      A domain with a challenge that is to be resolved
-    */
-    function resolveChallenge(string _domain) private {
-        bytes32 domainHash = keccak256(_domain);
-        Listing storage listing = listingMap[domainHash];
-        Challenge.Data storage challenge = challenges[listing.challengeID];
-
-        // Calculates the winner's reward,
-        // which is: (winner's full stake) + (dispensationPct * loser's stake)
-        uint winnerReward = challenge.challengeWinnerReward();
-
-        // Records whether the domain is a listing or an application
-        bool wasWhitelisted = isWhitelisted(_domain);
-
-        // Case: challenge failed
-        if (voting.isPassed(challenge.challengeID)) {
-            whitelistApplication(_domain);
-            // Unlock stake so that it can be retrieved by the applicant
-            listing.unstakedDeposit += winnerReward;
-
-            _ChallengeFailed(challenge.challengeID);
-            if (!wasWhitelisted) { _NewDomainWhitelisted(_domain); }
-        }
-        // Case: challenge succeeded
-        else {
-            resetListing(_domain);
-            // Transfer the reward to the challenger
-            require(token.transfer(challenge.challenger, winnerReward));
-
-            _ChallengeSucceeded(challenge.challengeID);
-            if (wasWhitelisted) { _ListingRemoved(_domain); }
-            else { _ApplicationRemoved(_domain); }
-        }
-
-        challenge.winningTokens =
-          challenge.voting.getTotalNumberOfTokensForWinningOption(challenge.challengeID);
-        challenge.resolved = true;
-    }
-
-    /**
-    @dev                Called by updateStatus() if the applicationExpiry date passed without a challenge being made.
-    @dev                Called by resolveChallenge() if an application/listing beat a challenge.
-    @param _domain      The domain of an application/listing to be whitelisted
-    */
-    function whitelistApplication(string _domain) private {
-        bytes32 domainHash = keccak256(_domain);
-
-        listingMap[domainHash].whitelisted = true;
-    }
 }

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -275,7 +275,8 @@ contract Registry {
 
     // Returns true if the application/listing has an unresolved challenge
     function challengeExists(string _domain) constant public returns (bool) {
-        return !challenges[listingMap[keccak256(_domain)].challengeID].isResolved();
+        Challenge.Data storage challenge = challenges[listingMap[keccak256(_domain)].challengeID];
+        return challenge.isInitialized() && !challenge.isResolved();
     }
 
     /**
@@ -284,7 +285,8 @@ contract Registry {
     @param _domain      A domain with an unresolved challenge
     */
     function challengeCanBeResolved(string _domain) constant public returns (bool) {
-        return challenges[listingMap[keccak256(_domain)].challengeID].canBeResolved();
+        Challenge.Data storage challenge = challenges[listingMap[keccak256(_domain)].challengeID];
+        return challenge.isInitialized() && challenge.canBeResolved();
     }
 
     /**

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -367,7 +367,9 @@ contract Registry {
             else { _ApplicationRemoved(_domain); }
         }
 
-        challenge.resolve();
+        challenge.winningTokens =
+          challenge.voting.getTotalNumberOfTokensForWinningOption(challenge.challengeID);
+        challenge.resolved = true;
     }
 
     /**

--- a/migrations/3_deploy_contracts.js
+++ b/migrations/3_deploy_contracts.js
@@ -5,6 +5,7 @@ const Token = artifacts.require('Token.sol');
 const Parameterizer = artifacts.require('Parameterizer.sol');
 const Sale = artifacts.require('historical/Sale.sol');
 const DLL = artifacts.require('DLL.sol');
+const Challenge = artifacts.require('Challenge.sol');
 const AttributeStore = artifacts.require('AttributeStore.sol');
 const PLCRVoting = artifacts.require('PLCRVoting.sol');
 
@@ -61,15 +62,18 @@ module.exports = (deployer, network, accounts) => {
 
   deployer.deploy(DLL);
   deployer.deploy(AttributeStore);
+  deployer.deploy(Challenge);
 
   deployer.link(DLL, PLCRVoting);
   deployer.link(AttributeStore, PLCRVoting);
 
   deployer.link(DLL, Parameterizer);
   deployer.link(AttributeStore, Parameterizer);
+  deployer.link(Challenge, Parameterizer);
 
   deployer.link(DLL, Registry);
   deployer.link(AttributeStore, Registry);
+  deployer.link(Challenge, Registry);
 
   return deployer.then(async () => {
     if (network !== 'mainnet') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,14 +55,14 @@
       "integrity": "sha1-lLiBq3FyhtAV+iGeCPtmcJ3aWj0="
     },
     "ajv": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
-      "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+      "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
       "requires": {
         "co": "4.6.0",
         "fast-deep-equal": "1.0.0",
-        "json-schema-traverse": "0.3.1",
-        "json-stable-stringify": "1.0.1"
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "ajv-keywords": {
@@ -274,12 +274,12 @@
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
         "convert-source-map": "1.5.0",
-        "debug": "2.6.9",
+        "debug": "2.6.8",
         "json5": "0.5.1",
         "lodash": "4.17.4",
         "minimatch": "3.0.4",
         "path-is-absolute": "1.0.1",
-        "private": "0.1.7",
+        "private": "0.1.8",
         "slash": "1.0.0",
         "source-map": "0.5.7"
       }
@@ -720,7 +720,7 @@
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
-        "debug": "2.6.9",
+        "debug": "2.6.8",
         "globals": "9.18.0",
         "invariant": "2.2.2",
         "lodash": "4.17.4"
@@ -866,9 +866,9 @@
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
     },
     "browserify-aes": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.8.tgz",
-      "integrity": "sha512-WYCMOT/PtGTlpOKFht0YJFYcPy6pLCR98CtWfzK13zoynLlBMvAdEMSRGmgnJCw2M2j/5qxBkinZQFobieM8dQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
+      "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
       "requires": {
         "buffer-xor": "1.0.3",
         "cipher-base": "1.0.4",
@@ -883,7 +883,7 @@
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
       "requires": {
-        "browserify-aes": "1.0.8",
+        "browserify-aes": "1.1.1",
         "browserify-des": "1.0.0",
         "evp_bytestokey": "1.0.3"
       }
@@ -1293,7 +1293,7 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
-        "es5-ext": "0.10.30"
+        "es5-ext": "0.10.35"
       }
     },
     "dashdash": {
@@ -1310,9 +1310,9 @@
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
       "requires": {
         "ms": "2.0.0"
       }
@@ -1420,7 +1420,7 @@
       "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
       "requires": {
         "bn.js": "4.11.8",
-        "miller-rabin": "4.0.0",
+        "miller-rabin": "4.0.1",
         "randombytes": "2.0.5"
       }
     },
@@ -1449,7 +1449,7 @@
       "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
       "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
       "requires": {
-        "browserify-aes": "1.0.8",
+        "browserify-aes": "1.1.1",
         "create-hash": "1.1.3",
         "create-hmac": "1.1.6"
       }
@@ -1526,9 +1526,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.2.tgz",
-      "integrity": "sha512-dvhwFL3yjQxNNsOWx6exMlaDrRHCRGMQlnx5lsXDCZ/J7G/frgIIl94zhZSp/galVAYp7VzPi1OrAHta89/yGQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.9.0.tgz",
+      "integrity": "sha512-kk3IJoKo7A3pWJc0OV8yZ/VEX2oSUytfekrJiqoxBlKJMFAJVJVpGdHClCCTdv+Fn2zHfpDHHIelMFhZVfef3Q==",
       "requires": {
         "es-to-primitive": "1.1.1",
         "function-bind": "1.1.1",
@@ -1548,21 +1548,21 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.30",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.30.tgz",
-      "integrity": "sha1-cUGhaDZpfbq/qq7uQUlc4p9SyTk=",
+      "version": "0.10.35",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz",
+      "integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
       "requires": {
-        "es6-iterator": "2.0.1",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
     },
     "es6-iterator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30",
+        "es5-ext": "0.10.35",
         "es6-symbol": "3.1.1"
       }
     },
@@ -1572,8 +1572,8 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30",
-        "es6-iterator": "2.0.1",
+        "es5-ext": "0.10.35",
+        "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -1585,8 +1585,8 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30",
-        "es6-iterator": "2.0.1",
+        "es5-ext": "0.10.35",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
       }
@@ -1597,7 +1597,7 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30"
+        "es5-ext": "0.10.35"
       }
     },
     "es6-weak-map": {
@@ -1606,8 +1606,8 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30",
-        "es6-iterator": "2.0.1",
+        "es5-ext": "0.10.35",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
     },
@@ -1633,12 +1633,12 @@
       "integrity": "sha1-mc1+r8/8ov+Zpcj18qR01jZLS9M=",
       "dev": true,
       "requires": {
-        "ajv": "5.2.3",
+        "ajv": "5.3.0",
         "babel-code-frame": "6.26.0",
         "chalk": "1.1.3",
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
-        "debug": "2.6.9",
+        "debug": "2.6.8",
         "doctrine": "2.0.0",
         "eslint-scope": "3.7.1",
         "espree": "3.5.1",
@@ -1649,7 +1649,7 @@
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
         "globals": "9.18.0",
-        "ignore": "3.3.5",
+        "ignore": "3.3.6",
         "imurmurhash": "0.1.4",
         "inquirer": "3.3.0",
         "is-resolvable": "1.0.0",
@@ -1667,8 +1667,24 @@
         "require-uncached": "1.0.3",
         "semver": "5.4.1",
         "strip-json-comments": "2.0.1",
-        "table": "4.0.1",
+        "table": "4.0.2",
         "text-table": "0.2.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
       }
     },
     "eslint-config-airbnb-base": {
@@ -1686,7 +1702,7 @@
       "integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
+        "debug": "2.6.8",
         "resolve": "1.4.0"
       }
     },
@@ -1696,7 +1712,7 @@
       "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
+        "debug": "2.6.8",
         "pkg-dir": "1.0.0"
       }
     },
@@ -1708,7 +1724,7 @@
       "requires": {
         "builtin-modules": "1.1.1",
         "contains-path": "0.1.0",
-        "debug": "2.6.9",
+        "debug": "2.6.8",
         "doctrine": "1.5.0",
         "eslint-import-resolver-node": "0.3.1",
         "eslint-module-utils": "2.1.1",
@@ -1791,9 +1807,9 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "ethereum-common": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
-      "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+      "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
     },
     "ethereumjs-abi": {
       "version": "0.6.4",
@@ -1814,12 +1830,12 @@
       }
     },
     "ethereumjs-block": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.6.0.tgz",
-      "integrity": "sha1-ze1JYt6soe7xc3K00pDoSzXIQ3I=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.0.tgz",
+      "integrity": "sha512-4s4Hh7mWa1xr+Bggh3T3jsq9lmje5aYpJRFky00bo/xNgNe+RC8V2ulWYSR4YTEKqLbnLEsLNytjDe5hpblkZQ==",
       "requires": {
         "async": "2.5.0",
-        "ethereum-common": "0.0.18",
+        "ethereum-common": "0.2.0",
         "ethereumjs-tx": "1.3.3",
         "ethereumjs-util": "5.1.2",
         "merkle-patricia-tree": "2.2.0"
@@ -1847,7 +1863,7 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-testrpc/-/ethereumjs-testrpc-4.1.1.tgz",
       "integrity": "sha512-NQjL/5chwWVjCOzVfsExdkw2yN+atFPGUVfxhyCh27fLBREcK0X2KU72b2kLaqkd4nIEjd68+O3zMtExzf43+w==",
       "requires": {
-        "webpack": "3.6.0"
+        "webpack": "3.8.1"
       }
     },
     "ethereumjs-tx": {
@@ -1859,6 +1875,11 @@
         "ethereumjs-util": "5.1.2"
       },
       "dependencies": {
+        "ethereum-common": {
+          "version": "0.0.18",
+          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
+          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
+        },
         "ethereumjs-util": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.2.tgz",
@@ -1889,27 +1910,21 @@
       }
     },
     "ethereumjs-vm": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.2.2.tgz",
-      "integrity": "sha512-sAus9UxYjUnA42G91Q1/hR7ff35IJRpcLrUfbaIH7V4cl8qKsNs3wqf3dHvtj3wRqy12ke2Wd0tYdARyGKdD6g==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.1.tgz",
+      "integrity": "sha512-LeOtE5tXYhnQk03WSEoqxeMs67EnPXPQ7EbaQotnM2uPf1dJWEM/WSIIww/DwPPO1rRpBqfZcGSJ6IFISeQf9Q==",
       "requires": {
         "async": "2.5.0",
         "async-eventemitter": "0.2.4",
-        "ethereum-common": "0.1.0",
+        "ethereum-common": "0.2.0",
         "ethereumjs-account": "2.0.4",
-        "ethereumjs-block": "1.6.0",
+        "ethereumjs-block": "1.7.0",
         "ethereumjs-util": "4.5.0",
         "fake-merkle-patricia-tree": "1.0.1",
         "functional-red-black-tree": "1.0.1",
         "merkle-patricia-tree": "2.2.0",
+        "rustbn.js": "0.1.0",
         "safe-buffer": "5.1.1"
-      },
-      "dependencies": {
-        "ethereum-common": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.1.0.tgz",
-          "integrity": "sha1-h03Q+uXpYqVsUOvyjvpv45SSsOc="
-        }
       }
     },
     "ethereumjs-wallet": {
@@ -1932,6 +1947,98 @@
           "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
         }
       }
+    },
+    "ethjs": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/ethjs/-/ethjs-0.2.8.tgz",
+      "integrity": "sha1-Ze0nbF5Y6J1R1Fc1hbehYULM+PA=",
+      "requires": {
+        "bn.js": "4.11.6",
+        "ethjs-abi": "0.2.0",
+        "ethjs-contract": "0.1.9",
+        "ethjs-filter": "0.1.5",
+        "ethjs-provider-http": "0.1.6",
+        "ethjs-query": "0.2.6",
+        "ethjs-unit": "0.1.6",
+        "ethjs-util": "0.1.3",
+        "js-sha3": "0.5.5",
+        "number-to-bn": "1.7.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        },
+        "ethjs-util": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.3.tgz",
+          "integrity": "sha1-39XqSkANxeQhqInK9H4IGtp4u1U=",
+          "requires": {
+            "is-hex-prefixed": "1.0.0",
+            "strip-hex-prefix": "1.0.0"
+          }
+        },
+        "js-sha3": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
+          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko="
+        }
+      }
+    },
+    "ethjs-abi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.2.0.tgz",
+      "integrity": "sha1-0+LCIQEVIPxJm3FoIDbBT8wvWyU=",
+      "requires": {
+        "bn.js": "4.11.6",
+        "js-sha3": "0.5.5",
+        "number-to-bn": "1.7.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        },
+        "js-sha3": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
+          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko="
+        }
+      }
+    },
+    "ethjs-contract": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/ethjs-contract/-/ethjs-contract-0.1.9.tgz",
+      "integrity": "sha1-HCdmiWpW1H7B1tZhgpxJzDilUgo=",
+      "requires": {
+        "ethjs-abi": "0.2.0",
+        "ethjs-filter": "0.1.5",
+        "ethjs-util": "0.1.3",
+        "js-sha3": "0.5.5"
+      },
+      "dependencies": {
+        "ethjs-util": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.3.tgz",
+          "integrity": "sha1-39XqSkANxeQhqInK9H4IGtp4u1U=",
+          "requires": {
+            "is-hex-prefixed": "1.0.0",
+            "strip-hex-prefix": "1.0.0"
+          }
+        },
+        "js-sha3": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
+          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko="
+        }
+      }
+    },
+    "ethjs-filter": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/ethjs-filter/-/ethjs-filter-0.1.5.tgz",
+      "integrity": "sha1-ARKvYBfCRnfjK4/esg5hlgGbdZg="
     },
     "ethjs-format": {
       "version": "0.2.0",
@@ -1989,6 +2096,22 @@
       "resolved": "https://registry.npmjs.org/ethjs-schema/-/ethjs-schema-0.1.5.tgz",
       "integrity": "sha1-WXQOOzl3vNu5sRvDBoIB6Kzquw0="
     },
+    "ethjs-unit": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
+      "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
+      "requires": {
+        "bn.js": "4.11.6",
+        "number-to-bn": "1.7.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        }
+      }
+    },
     "ethjs-util": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.4.tgz",
@@ -2004,7 +2127,7 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30"
+        "es5-ext": "0.10.35"
       }
     },
     "events": {
@@ -2098,6 +2221,11 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
     },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -2119,7 +2247,7 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.2.2",
+        "flat-cache": "1.3.0",
         "object-assign": "4.1.1"
       }
     },
@@ -2149,9 +2277,9 @@
       }
     },
     "flat-cache": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-      "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
         "circular-json": "0.3.3",
@@ -2267,9 +2395,9 @@
       "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -2325,7 +2453,7 @@
       "requires": {
         "array-union": "1.0.2",
         "arrify": "1.0.1",
-        "glob": "7.1.2",
+        "glob": "7.1.1",
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
@@ -2356,7 +2484,7 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.2.3",
+        "ajv": "5.3.0",
         "har-schema": "2.0.0"
       }
     },
@@ -2483,9 +2611,9 @@
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
     },
     "ignore": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
-      "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz",
+      "integrity": "sha512-HrxmNxKTGZ9a3uAl/FNG66Sdt0G9L4TtMbbUQjP1WhGmSj0FOyHvSgx7623aGJvXfPOur8MwmarlHT+37jmzlw==",
       "dev": true
     },
     "immediate": {
@@ -2530,7 +2658,7 @@
       "dev": true,
       "requires": {
         "ansi-escapes": "3.0.0",
-        "chalk": "2.1.0",
+        "chalk": "2.3.0",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
         "external-editor": "2.0.5",
@@ -2561,14 +2689,14 @@
           }
         },
         "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
+            "supports-color": "4.5.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -2887,6 +3015,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
       "requires": {
         "jsonify": "0.0.0"
       }
@@ -2917,7 +3046,8 @@
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
@@ -2938,7 +3068,7 @@
         "bindings": "1.3.0",
         "inherits": "2.0.3",
         "nan": "2.7.0",
-        "prebuild-install": "2.2.2",
+        "prebuild-install": "2.3.0",
         "safe-buffer": "5.1.1"
       }
     },
@@ -3264,21 +3394,22 @@
       }
     },
     "memdown": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.3.1.tgz",
-      "integrity": "sha512-Qr0bqzSQWUEU0/nwSOOo3j7Gt/I3lKUoUENmsZiJ7YZoPtt0WrfV4h1Qbv/XurwBCN9qt3zR68Vfk0iY5cBDSQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
+      "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
       "requires": {
-        "abstract-leveldown": "2.7.0",
+        "abstract-leveldown": "2.7.2",
         "functional-red-black-tree": "1.0.1",
         "immediate": "3.2.3",
         "inherits": "2.0.3",
-        "ltgt": "2.2.0"
+        "ltgt": "2.2.0",
+        "safe-buffer": "5.1.1"
       },
       "dependencies": {
         "abstract-leveldown": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.0.tgz",
-          "integrity": "sha512-maam3ZrTeORbXKEJUeJZkYOsorEwr060WitXuQlUuIFlg0RofyyHts49wtaVmShJ6l0wEWB0ZtPhf6QYBA7D2w==",
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+          "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
           "requires": {
             "xtend": "4.0.1"
           }
@@ -3308,7 +3439,7 @@
         "ethereumjs-util": "4.5.0",
         "level-ws": "0.0.0",
         "levelup": "1.3.9",
-        "memdown": "1.3.1",
+        "memdown": "1.4.1",
         "readable-stream": "2.3.3",
         "rlp": "2.0.0",
         "semaphore": "1.1.0"
@@ -3342,9 +3473,9 @@
       }
     },
     "miller-rabin": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
-      "integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "requires": {
         "bn.js": "4.11.8",
         "brorand": "1.1.0"
@@ -3433,27 +3564,6 @@
         "supports-color": "3.1.2"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
         "has-flag": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
@@ -3759,7 +3869,7 @@
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "requires": {
         "asn1.js": "4.9.1",
-        "browserify-aes": "1.0.8",
+        "browserify-aes": "1.1.1",
         "create-hash": "1.1.3",
         "evp_bytestokey": "1.0.3",
         "pbkdf2": "3.0.14"
@@ -3904,9 +4014,9 @@
       "dev": true
     },
     "prebuild-install": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.2.2.tgz",
-      "integrity": "sha512-F46pcvDxtQhbV3B+dm+exHuKxIyJK26fVNiJRmbTW/5D7o0Z2yzc8CKeu7UWbo9XxQZoVOC88aKgySAsza+cWw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.3.0.tgz",
+      "integrity": "sha512-gzjq2oHB8oMbzJSsSh9MQ64zrXZGt092/uT4TLZlz2qnrPxpWqp4vYB7LZrDxnlxf5RfbCjkgDI/z0EIVuYzAw==",
       "requires": {
         "expand-template": "1.1.0",
         "github-from-package": "0.0.0",
@@ -3917,9 +4027,9 @@
         "npmlog": "4.1.2",
         "os-homedir": "1.0.2",
         "pump": "1.0.2",
-        "rc": "1.2.1",
+        "rc": "1.2.2",
         "simple-get": "1.4.3",
-        "tar-fs": "1.15.3",
+        "tar-fs": "1.16.0",
         "tunnel-agent": "0.6.0",
         "xtend": "4.0.1"
       }
@@ -3936,9 +4046,9 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
     "private": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-      "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE="
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
     },
     "process": {
       "version": "0.11.10",
@@ -4053,9 +4163,9 @@
       }
     },
     "rc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
+      "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
       "requires": {
         "deep-extend": "0.4.2",
         "ini": "1.3.4",
@@ -4124,7 +4234,7 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
-        "private": "0.1.7"
+        "private": "0.1.8"
       }
     },
     "regex-cache": {
@@ -4182,9 +4292,9 @@
       }
     },
     "request": {
-      "version": "2.82.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.82.0.tgz",
-      "integrity": "sha512-/QWqfmyTfQ4OYs6EhB1h2wQsX9ZxbuNePCvCm0Mdz/mxw73mjdg0D4QdIl0TQBFs35CZmMXLjk0iCGK395CUDg==",
+      "version": "2.83.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.6.0",
@@ -4287,7 +4397,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "7.1.2"
+        "glob": "7.1.1"
       }
     },
     "ripemd160": {
@@ -4312,6 +4422,11 @@
       "requires": {
         "is-promise": "2.1.0"
       }
+    },
+    "rustbn.js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.0.tgz",
+      "integrity": "sha512-AFsqeHid+1evulpDnqQuuXkh79Xl3VdUmvCRMeRxnEdEW4TDu6tBMxVTrqiT/vCsmxgrIcdrWVQW0utrGr+G6Q=="
     },
     "rx-lite": {
       "version": "4.0.8",
@@ -4375,7 +4490,7 @@
         "drbg.js": "1.0.1",
         "elliptic": "6.4.0",
         "nan": "2.7.0",
-        "prebuild-install": "2.2.2",
+        "prebuild-install": "2.3.0",
         "safe-buffer": "5.1.1"
       }
     },
@@ -4455,10 +4570,21 @@
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
     "slice-ansi": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        }
+      }
     },
     "sntp": {
       "version": "2.0.2",
@@ -4469,9 +4595,9 @@
       }
     },
     "solc": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.17.tgz",
-      "integrity": "sha512-39Tmo2r+qclwW7ooLXMLzMSxmoGtHy3/p2sDKdA9NM/+MRtzLm/AFKj4BY2Cocg3gwkfJzKTEx6X0wiI4fIZ/A==",
+      "version": "0.4.15",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.15.tgz",
+      "integrity": "sha1-iujxYGoSSj+BwoudzssJZOvfnyU=",
       "requires": {
         "fs-extra": "0.30.0",
         "memorystream": "0.3.1",
@@ -4689,14 +4815,6 @@
         "xtend": "4.0.1"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -4713,8 +4831,16 @@
       "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.8.2",
+        "es-abstract": "1.9.0",
         "function-bind": "1.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {
@@ -4754,48 +4880,52 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "supports-color": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+      "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
       "requires": {
         "has-flag": "2.0.0"
       }
     },
     "table": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.1.tgz",
-      "integrity": "sha1-qBFsEz+sLGH0pCCrbN9cTWHw5DU=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "chalk": "1.1.3",
+        "ajv": "5.3.0",
+        "ajv-keywords": "2.1.0",
+        "chalk": "2.3.0",
         "lodash": "4.17.4",
-        "slice-ansi": "0.0.4",
+        "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
       },
       "dependencies": {
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "ajv-keywords": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-          "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
-          "dev": true
-        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -4847,12 +4977,27 @@
         "resumer": "0.0.0",
         "string.prototype.trim": "1.1.2",
         "through": "2.3.8"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
       }
     },
     "tar-fs": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.15.3.tgz",
-      "integrity": "sha1-7M+TXpQUk9gVECjmNuUc5MPKfyA=",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz",
+      "integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
       "requires": {
         "chownr": "1.0.1",
         "mkdirp": "0.5.1",
@@ -4942,149 +5087,6 @@
         "mocha": "3.5.3",
         "original-require": "1.0.1",
         "solc": "0.4.15"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
-          }
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
-        "os-locale": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-          "requires": {
-            "lcid": "1.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          }
-        },
-        "solc": {
-          "version": "0.4.15",
-          "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.15.tgz",
-          "integrity": "sha1-iujxYGoSSj+BwoudzssJZOvfnyU=",
-          "requires": {
-            "fs-extra": "0.30.0",
-            "memorystream": "0.3.1",
-            "require-from-string": "1.2.1",
-            "semver": "5.4.1",
-            "yargs": "4.8.1"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        },
-        "which-module": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-        },
-        "window-size": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-          "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
-        },
-        "yargs": {
-          "version": "4.8.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-          "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
-          "requires": {
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "lodash.assign": "4.2.0",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "window-size": "0.2.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "2.4.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-          "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
-          "requires": {
-            "camelcase": "3.0.0",
-            "lodash.assign": "4.2.0"
-          }
-        }
       }
     },
     "truffle-hdwallet-provider": {
@@ -5287,14 +5289,14 @@
       "requires": {
         "async": "2.5.0",
         "clone": "2.1.1",
-        "ethereumjs-block": "1.6.0",
+        "ethereumjs-block": "1.7.0",
         "ethereumjs-tx": "1.3.3",
         "ethereumjs-util": "5.1.2",
-        "ethereumjs-vm": "2.2.2",
+        "ethereumjs-vm": "2.3.1",
         "isomorphic-fetch": "2.2.1",
-        "request": "2.82.0",
+        "request": "2.83.0",
         "semaphore": "1.1.0",
-        "solc": "0.4.17",
+        "solc": "0.4.15",
         "tape": "4.8.0",
         "web3": "0.16.0",
         "xhr": "2.4.0",
@@ -5333,13 +5335,13 @@
       }
     },
     "webpack": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.6.0.tgz",
-      "integrity": "sha512-OsHT3D0W0KmPPh60tC7asNnOmST6bKTiR90UyEdT9QYoaJ4OYN4Gg7WK1k3VxHK07ZoiYWPsKvlS/gAjwL/vRA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.8.1.tgz",
+      "integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
       "requires": {
         "acorn": "5.1.2",
         "acorn-dynamic-import": "2.0.2",
-        "ajv": "5.2.3",
+        "ajv": "5.3.0",
         "ajv-keywords": "2.1.0",
         "async": "2.5.0",
         "enhanced-resolve": "3.4.1",
@@ -5353,7 +5355,7 @@
         "mkdirp": "0.5.1",
         "node-libs-browser": "2.0.0",
         "source-map": "0.5.7",
-        "supports-color": "4.4.0",
+        "supports-color": "4.5.0",
         "tapable": "0.2.8",
         "uglifyjs-webpack-plugin": "0.4.6",
         "watchpack": "1.4.0",

--- a/test/parameterizer.js
+++ b/test/parameterizer.js
@@ -331,12 +331,12 @@ contract('Parameterizer', (accounts) => {
 
         await parameterizer.processProposal(propID);
 
-        const voterAliceReward = await parameterizer.calculateVoterReward.call(voterAlice,
+        const voterAliceReward = await parameterizer.voterReward.call(voterAlice,
           challengeID, '420');
         await utils.as(voterAlice, parameterizer.claimReward, challengeID, '420');
         await utils.as(voterAlice, voting.withdrawVotingRights, '10');
 
-        const voterBobReward = await parameterizer.calculateVoterReward.call(voterBob,
+        const voterBobReward = await parameterizer.voterReward.call(voterBob,
           challengeID, '420');
         await utils.as(voterBob, parameterizer.claimReward, challengeID, '420');
         await utils.as(voterBob, voting.withdrawVotingRights, '20');
@@ -426,7 +426,7 @@ contract('Parameterizer', (accounts) => {
       const totalTokens = challenge[7]; // 10
 
       const expectedVoterReward = (voterTokens.mul(rewardPool)).div(totalTokens); // 250,000
-      const voterReward = await parameterizer.calculateVoterReward(voterAlice, challengeID, '420');
+      const voterReward = await parameterizer.voterReward(voterAlice, challengeID, '420');
 
       assert.strictEqual(expectedVoterReward.toString(10), voterReward.toString(10),
         'voterReward should have equaled tokens * pool / total');

--- a/test/parameterizer.js
+++ b/test/parameterizer.js
@@ -28,7 +28,7 @@ contract('Parameterizer', (accounts) => {
       );
 
       const propID = utils.getReceiptValue(receipt, 'propID');
-      const paramProposal = await parameterizer.proposalMap.call(propID);
+      const paramProposal = await parameterizer.proposals.call(propID);
 
       assert.strictEqual(paramProposal[6].toString(10), '51', 'The reparameterization proposal ' +
         'was not created, or not created correctly.');
@@ -194,7 +194,7 @@ contract('Parameterizer', (accounts) => {
       );
 
       const propID = receipt.logs[0].args.propID;
-      const paramProp = await parameterizer.proposalMap.call(propID);
+      const paramProp = await parameterizer.proposals.call(propID);
       const processBy = paramProp[5];
       await utils.increaseTime(processBy.toNumber() + 1);
 
@@ -230,7 +230,7 @@ contract('Parameterizer', (accounts) => {
 
       await utils.as(voter, voting.revealVote, pollID, '0', '420');
 
-      const paramProp = await parameterizer.proposalMap.call(propID);
+      const paramProp = await parameterizer.proposals.call(propID);
       const processBy = paramProp[5];
       await utils.increaseTime(processBy.toNumber() + 1);
 

--- a/test/parameterizer.js
+++ b/test/parameterizer.js
@@ -420,10 +420,10 @@ contract('Parameterizer', (accounts) => {
       await parameterizer.processProposal(propID);
 
       // Grab the challenge struct after the proposal has been processed
-      const challenge = await parameterizer.challengeMap.call(challengeID);
+      const challenge = await parameterizer.challenges.call(challengeID);
       const voterTokens = await voting.getNumPassingTokens(voterAlice, challengeID, '420'); // 10
       const rewardPool = challenge[0]; // 250,000
-      const totalTokens = challenge[4]; // 10
+      const totalTokens = challenge[7]; // 10
 
       const expectedVoterReward = (voterTokens.mul(rewardPool)).div(totalTokens); // 250,000
       const voterReward = await parameterizer.calculateVoterReward(voterAlice, challengeID, '420');

--- a/test/registry.js
+++ b/test/registry.js
@@ -502,7 +502,7 @@ contract('Registry', (accounts) => {
       await utils.as(applicant, registry.apply, domain, minDeposit);
 
       const hash = utils.getDomainHash(domain);
-      const result = await registry.listingMap.call(hash);
+      const result = await registry.listings.call(hash);
 
       // Voting period done (ie. app expired)
       await utils.increaseTime(paramConfig.commitStageLength + paramConfig.revealStageLength + 1);
@@ -518,7 +518,7 @@ contract('Registry', (accounts) => {
       await utils.as(applicant, registry.apply, domain, minDeposit);
 
       const hash = utils.getDomainHash(domain);
-      const result = await registry.listingMap.call(hash);
+      const result = await registry.listings.call(hash);
 
       const isExpired = await registry.isExpired(result[0]);
       assert.strictEqual(isExpired, false, 'application should not have expired.');
@@ -556,10 +556,10 @@ contract('Registry', (accounts) => {
       const domain = 'nochallenge.net';
       // apply with accounts[1]
       await registry.apply(domain, paramConfig.minDeposit, { from: accounts[1] });
-      // hash the domain so we can identify in listingMap
+      // hash the domain so we can identify in listings
       const hash = utils.getDomainHash(domain);
       // get the struct in the mapping
-      const result = await registry.listingMap.call(hash);
+      const result = await registry.listings.call(hash);
       // check that Application is initialized correctly
       assert.strictEqual(result[0] * 1000 > Date.now(), true, 'challenge time < now');
       assert.strictEqual(result[1], false, 'challenged != false');

--- a/test/registry.js
+++ b/test/registry.js
@@ -256,7 +256,7 @@ contract('Registry', (accounts) => {
       await utils.as(applicant, registry.updateStatus, domain);
 
       // Alice claims reward
-      const aliceVoterReward = await registry.calculateVoterReward(voterAlice, pollID, '420');
+      const aliceVoterReward = await registry.voterReward(voterAlice, pollID, '420');
       await utils.as(voterAlice, registry.claimReward, pollID, '420');
 
       // Alice withdraws her voting rights

--- a/test/utils.js
+++ b/test/utils.js
@@ -100,10 +100,10 @@ const utils = {
 
   getUnstakedDeposit: async (domain) => {
     const registry = await Registry.deployed();
-    // hash the domain so we can identify in listingMap
+    // hash the domain so we can identify in listings
     const hash = utils.getDomainHash(domain);
     // get the struct in the mapping
-    const listing = await registry.listingMap.call(hash);
+    const listing = await registry.listings.call(hash);
     // get the unstaked deposit amount from the listing struct
     const unstakedDeposit = await listing[3];
     return unstakedDeposit.toString();


### PR DESCRIPTION
As per previous conversations, I've removed the `resolve` function from the `Challenge` library in https://github.com/AdChain/AdChainRegistry/commit/a49bc46fabb6ca65b0749a8e766fd69514d4f12a:
```
The resolve member function of the Challenge struct made state changes
which would result in only the partial completion of the resolution
task. This was more dangerous than the code it de-duped, because it
made it seem that other *necessary* state changes that might be required
in the complete resolution of a challenge might be done by the resolve
method. They're not. Challenge resolutions are heterogenous, and short
of being able to pass function types into a resolve method, the resolver
itself needs to operate on the internal state of the Challenge struct.
More important to keep that totally explicit than it is to dedupe a
small number of lines. (Though if, in the future, we could solve this
more elegantly that would be highly desirable).
```
With that out of the way, I feel this PR is something of a half-measure but still an overall improvement to the codebase. Compare: https://github.com/AdChain/AdChainRegistry/compare/develop...a49bc46fabb6ca65b0749a8e766fd69514d4f12a

This does not actually reduce our testing burden, but it does allow us to dedupe some code and separate concerns. With the `resolve` method removed it doesn't confuse who gets to change internal state: the contract in which the Challenge resides must mutate its state to resolve a challenge, and we bundle that up in one private (implicitly dangerous) method.

The final commit in this branch makes a bunch of formatting improvements.

BREAKING CHANGES:
`determineReward` -> `challengeWinnerReward`
`calculateVoterReward` -> `voterReward`

Just name changes. Arguments and returns are the same.